### PR TITLE
Hotfix Workflows CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 16
           registry-url: 'https://registry.npmjs.org/'
       - run: yarn run ci
       - run: yarn run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 16
       - run: yarn run ci
       - run: yarn test


### PR DESCRIPTION
For some reasons the node-version: latest is not recognized. So now it has been set to 16.