### PR TITLE
Use MailerModuleOptions

### DIFF
--- a/lib/mailer.interface.ts
+++ b/lib/mailer.interface.ts
@@ -58,14 +58,16 @@ export interface MailerModuleOptions {
 }
 
 export interface MailerTransportFactory {
-  createMailerTransports(): Promise<MailerTransport[]> | MailerTransport[];
+  createMailerModuleOptions():
+    | Promise<MailerModuleOptions>
+    | MailerModuleOptions;
 }
 
 export interface MailerModuleAsyncOptions
   extends Pick<ModuleMetadata, 'imports'> {
   inject?: any[];
   useFactory?: FactoryProvider<
-    Promise<MailerTransport[]> | MailerTransport[]
+    Promise<MailerModuleOptions> | MailerModuleOptions
   >['useFactory'];
   useExisting?: ExistingProvider<MailerTransportFactory>['useExisting'];
   useClass?: ClassProvider<MailerTransportFactory>['useClass'];

--- a/lib/mailer.interface.ts
+++ b/lib/mailer.interface.ts
@@ -55,11 +55,6 @@ export interface MailerModuleOptions {
    * Array of Mailer Transport object.
    */
   transports: MailerTransport[];
-
-  /**
-   * When "true", makes the module global-scoped.
-   */
-  global?: boolean;
 }
 
 export interface MailerTransportFactory {
@@ -67,8 +62,7 @@ export interface MailerTransportFactory {
 }
 
 export interface MailerModuleAsyncOptions
-  extends Pick<ModuleMetadata, 'imports'>,
-    Pick<MailerModuleOptions, 'global'> {
+  extends Pick<ModuleMetadata, 'imports'> {
   inject?: any[];
   useFactory?: FactoryProvider<
     Promise<MailerTransport[]> | MailerTransport[]

--- a/lib/mailer.module.ts
+++ b/lib/mailer.module.ts
@@ -18,7 +18,7 @@ import { MailerService } from './mailer.service';
 @Module({})
 export class MailerModule {
   public static forRoot(
-    options: MailerModuleOptions & { global?: boolean },
+    options: MailerModuleOptions & { isGlobal?: boolean },
   ): DynamicModule {
     const MailerOptionsProvider: ValueProvider<MailerModuleOptions> = {
       provide: MAILER_OPTIONS,
@@ -29,12 +29,12 @@ export class MailerModule {
       module: MailerModule,
       providers: [MailerOptionsProvider, MailerService],
       exports: [MailerService],
-      global: options.global || false,
+      global: options.isGlobal || false,
     };
   }
 
   public static forRootAsync(
-    options: MailerModuleAsyncOptions & { global: boolean },
+    options: MailerModuleAsyncOptions & { isGlobal: boolean },
   ): DynamicModule {
     const MailerAsyncProviders: Provider[] = this.createAsyncProviders(options);
 
@@ -43,7 +43,7 @@ export class MailerModule {
       providers: [...MailerAsyncProviders, MailerService],
       imports: options.imports || [],
       exports: [MailerService],
-      global: options.global || false,
+      global: options.isGlobal || false,
     };
   }
 

--- a/lib/mailer.module.ts
+++ b/lib/mailer.module.ts
@@ -11,17 +11,18 @@ import { MAILER_OPTIONS } from './mailer.constants';
 import {
   MailerModuleAsyncOptions,
   MailerModuleOptions,
-  MailerTransport,
   MailerTransportFactory,
 } from './mailer.interface';
 import { MailerService } from './mailer.service';
 
 @Module({})
 export class MailerModule {
-  public static forRoot(options: MailerModuleOptions): DynamicModule {
-    const MailerOptionsProvider: ValueProvider<MailerTransport[]> = {
+  public static forRoot(
+    options: MailerModuleOptions & { global?: boolean },
+  ): DynamicModule {
+    const MailerOptionsProvider: ValueProvider<MailerModuleOptions> = {
       provide: MAILER_OPTIONS,
-      useValue: options.transports,
+      useValue: options,
     };
 
     return {
@@ -32,7 +33,9 @@ export class MailerModule {
     };
   }
 
-  public static forRootAsync(options: MailerModuleAsyncOptions): DynamicModule {
+  public static forRootAsync(
+    options: MailerModuleAsyncOptions & { global: boolean },
+  ): DynamicModule {
     const MailerAsyncProviders: Provider[] = this.createAsyncProviders(options);
 
     return {
@@ -76,7 +79,7 @@ export class MailerModule {
   ): FactoryProvider {
     return {
       provide: MAILER_OPTIONS,
-      useFactory: (f: MailerTransportFactory) => f.createMailerTransports(),
+      useFactory: (f: MailerTransportFactory) => f.createMailerModuleOptions(),
       inject: [options.useClass || options.useExisting],
     };
   }

--- a/lib/mailer.service.spec.ts
+++ b/lib/mailer.service.spec.ts
@@ -20,10 +20,7 @@ async function createMailerService(
   options: MailerModuleOptions,
 ): Promise<MailerService> {
   const module: TestingModule = await Test.createTestingModule({
-    providers: [
-      MailerService,
-      { provide: MAILER_OPTIONS, useValue: options.transports },
-    ],
+    providers: [MailerService, { provide: MAILER_OPTIONS, useValue: options }],
   }).compile();
 
   const service = module.get<MailerService>(MailerService);
@@ -254,12 +251,16 @@ describe('MailerService', () => {
 
   it('should be defined with custom factory', async () => {
     const service = await createAsyncMailerService({
-      useFactory: () => [
-        {
-          name: 'smtp',
-          transport: SMTP_CONNECTION,
-        },
-      ],
+      useFactory: () => {
+        return {
+          transports: [
+            {
+              name: 'smtp',
+              transport: SMTP_CONNECTION,
+            },
+          ],
+        };
+      },
     });
 
     expect(service).toBeDefined();
@@ -271,12 +272,14 @@ describe('MailerService', () => {
   it('should be defined with custom async factory', async () => {
     const service = await createAsyncMailerService({
       useFactory: async () => {
-        return [
-          {
-            name: 'smtp',
-            transport: SMTP_CONNECTION,
-          },
-        ];
+        return {
+          transports: [
+            {
+              name: 'smtp',
+              transport: SMTP_CONNECTION,
+            },
+          ],
+        };
       },
     });
 

--- a/lib/mailer.service.ts
+++ b/lib/mailer.service.ts
@@ -3,16 +3,20 @@ import { SentMessageInfo, Transporter, createTransport } from 'nodemailer';
 import Mail from 'nodemailer/lib/mailer';
 
 import { MAILER_OPTIONS } from './mailer.constants';
-import { MailerTransport, MailerTransporter } from './mailer.interface';
+import {
+  MailerModuleOptions,
+  MailerTransport,
+  MailerTransporter,
+} from './mailer.interface';
 
 @Injectable()
 export class MailerService {
   private transporters = new Map<string, MailerTransporter>();
 
   public constructor(
-    @Inject(MAILER_OPTIONS) mailerTransports: MailerTransport[],
+    @Inject(MAILER_OPTIONS) mailerModuleOptions: MailerModuleOptions,
   ) {
-    this.initTransporters(mailerTransports);
+    this.initTransporters(mailerModuleOptions.transports);
   }
 
   /**


### PR DESCRIPTION
This feature introduces the following breaking changes:

- "global" option has been renamed as "isGlobal" and is no longer available in MailerModuleOptions interface.
- The method of MailerTransportFactory interface has been renamed from "createMailerTransports()" to "createMailerModuleOptions()", and now it must return Promise\<MailerModuleOptions\> | MailerModuleOptions.
- useFactory must return Promise\<MailerModuleOptions\> | MailerModuleOptions.
- MailerService constructor now accepts a MailerModuleOptions.
