### PR TITLE
Feature - Support plugins

### DIFF
--- a/lib/mailer.interface.ts
+++ b/lib/mailer.interface.ts
@@ -50,7 +50,7 @@ export enum MailerPluginStep {
 }
 
 export type MailerPluginOptions = {
-  [step in MailerPluginStep]: Mail.PluginFunction;
+  [step in MailerPluginStep]?: Mail.PluginFunction;
 };
 
 export interface MailerTransport {

--- a/lib/mailer.interface.ts
+++ b/lib/mailer.interface.ts
@@ -9,7 +9,8 @@ import {
   FactoryProvider,
   ModuleMetadata,
 } from '@nestjs/common';
-import { Transporter } from 'nodemailer';
+import { Transport, TransportOptions, Transporter } from 'nodemailer';
+import Mail from 'nodemailer/lib/mailer';
 
 export type MailerTransportType =
   | JSONTransport
@@ -17,6 +18,7 @@ export type MailerTransportType =
   | SESTransport
   | SMTPTransport
   | StreamTransport
+  | Transport
   | string;
 
 export type MailerTransportOptions =
@@ -24,7 +26,32 @@ export type MailerTransportOptions =
   | SendmailTransport.Options
   | SESTransport.Options
   | SMTPTransport.Options
-  | StreamTransport.Options;
+  | StreamTransport.Options
+  | TransportOptions;
+
+/**
+ * Stage in which the plugin should be hooked.
+ */
+export enum MailerPluginStep {
+  /**
+   * Step where the email data is set but nothing has been done with it yet.
+   * At this step you can modify mail options, for example modify html content,
+   * add new headers etc.
+   */
+  COMPILE = 'compile',
+
+  /**
+   * Step where message tree has been compiled and is ready to be streamed.
+   * At this step you can modify the generated MIME tree or add a transform
+   * stream that the generated raw email will be piped through before passed
+   * to the transport object.
+   */
+  STREAM = 'stream',
+}
+
+export type MailerPluginOptions = {
+  [step in MailerPluginStep]: Mail.PluginFunction;
+};
 
 export interface MailerTransport {
   /**
@@ -41,6 +68,11 @@ export interface MailerTransport {
    * Object that defines values for mail options.
    */
   defaults?: MailerTransportOptions;
+
+  /**
+   * Plugins to be associated with the transporter.
+   */
+  plugins?: MailerPluginOptions;
 }
 
 export interface MailerTransporter {

--- a/lib/mailer.service.ts
+++ b/lib/mailer.service.ts
@@ -78,11 +78,11 @@ export class MailerService {
     const stream = mailerTransport?.plugins?.stream;
 
     if (compile) {
-      transporter.use(MailerPluginStep.COMPILE, compile as Mail.PluginFunction);
+      transporter.use(MailerPluginStep.COMPILE, compile);
     }
 
     if (stream) {
-      transporter.use(MailerPluginStep.STREAM, stream as Mail.PluginFunction);
+      transporter.use(MailerPluginStep.STREAM, stream);
     }
   }
 

--- a/lib/mailer.service.ts
+++ b/lib/mailer.service.ts
@@ -5,6 +5,7 @@ import Mail from 'nodemailer/lib/mailer';
 import { MAILER_OPTIONS } from './mailer.constants';
 import {
   MailerModuleOptions,
+  MailerPluginStep,
   MailerTransport,
   MailerTransporter,
 } from './mailer.interface';
@@ -62,9 +63,27 @@ export class MailerService {
       mailerTransport.defaults,
     );
 
+    this.initPlugins(newTransporter, mailerTransport);
+
     this.transporters.set(mailerTransport.name, {
       transporter: newTransporter,
     });
+  }
+
+  private initPlugins(
+    transporter: Transporter,
+    mailerTransport: MailerTransport,
+  ): void {
+    const compile = mailerTransport?.plugins?.compile;
+    const stream = mailerTransport?.plugins?.stream;
+
+    if (compile) {
+      transporter.use(MailerPluginStep.COMPILE, compile as Mail.PluginFunction);
+    }
+
+    if (stream) {
+      transporter.use(MailerPluginStep.STREAM, stream as Mail.PluginFunction);
+    }
   }
 
   private initTransporters(mailerTransports: MailerTransport[]) {


### PR DESCRIPTION
Plugins:
- add MailerPluginStep (compile and stream)
- add MailerPluginOptions (which is an object [key: MailerPluginStep]: Mail.PluginFunction)
- add plugins option to MailerTransport.

Custom transport:
- add Transport interface to MailerTransportType
- add TransportOptions interface to MailerTransportOptions

